### PR TITLE
fix headers sizes site wide and mc/mpa typo

### DIFF
--- a/Airlines/index.html
+++ b/Airlines/index.html
@@ -17,13 +17,13 @@
 	</ul>
 
 		
-		<h3>What is the best flight to take from Boston to popular destinations?</h3>
+		<h1>What is the best flight to take from Boston to popular destinations?</h1>
 		<p>Flight delay is a serious and widespread problem in the United States. In 2007, nearly one in four airline flights arrived at its destination over 15 minutes late (BTS,  2009).  About  a  third  of  
 		these  late  arrivals  were  a  direct  result  of  the  inability  of  the  aviation  system  to  handle  the  traffic  demands  that  were  placed  upon  it,  while  another  third  resulted  from  airline  internal  problems. Most of the remainder was caused by an aircraft arriving late and thus having to depart late on its next flight (BTS, 2009). </p>
 
 		<p>As a frequent flier from Boston to other major cities, it is very useful to check the length of flight delays to plan your trip to the airport.</p>
 		<p>Below is an interactive bar graph that charts predicted length of delays for various airlines flying out of Boston. This information can be used to decide which airline to take.</p>
-		<h3>Insights</h3>
+		<h2>Insights</h2>
 		<ul>
 		<li><b>Delta</b> is consistently predicted to have the longest flight delays across all routes.</li>
 		<li><b>JetBlue</b> is predited to have the shortest flight delays across all routes.</li>

--- a/FlightDay/index.html
+++ b/FlightDay/index.html
@@ -17,22 +17,24 @@
 		  <li class="navBar_li"><a href="../PlaneType">Planes</a></li>
 	</ul>
 
-	<H1>When is the Best Time to Fly if You Want To Avoid Flight Delays?</H1>
+	<H1>When is the best time to fly if you want to avoid flight delays?</H1>
 
-	<h3>Source of Data</h3>
+	<p>Does the time of flight affect the chances of it being delays? Is there a prefered day or month to fly if you want to minimize the chances of your flight being delayed?</p>
+
+	<h2>Source of Data</h2>
 	<p>Data was gathered from the Department of Transportation's web site  <A HREF="https://www.transtats.bts.gov/ONTIME/">On-Time Performances Table</A>, between November 2016 and October 2017 (inclusive).</p>
 	<p>The data was processed in order to create a histogram of late flights by different time periods. Delay is considered when a flight arrived more than 15 minutes after its planned time. The data includes all domestic flights and delays for all reasons (security, weather, etc.)</p>
 
 	<p>For any available graph (day of week, day of month, and month of year) the percentage of delayed flights is shown. The category with the most delays is marked with a <font color="#c94c4c"><b>red</b></font> bar, while the category with the least delays is marked with a <font color="#86af49"><b>green</b></font> bar.</p>
 
-	<h3>Insights</h3>
+	<h2>Insights</h2>
 	<ul>
 	<li>If you plan to fly on <b>Friday</b>, the chances of your flight being delayed are <b>5%(!)</b> higher than when flying on <b>Saturday</b>.</li>
 	<li>The <b>7th</b> day of every month has the highest chance of having a delayed flight (over 21%).</li>
 	<li><b>December</b> is the worst month to fly if you want to avoid flight delays. The chances of your flight being delayed in <b>November</b> are almost <b>10%</b> less than in December.</li>
 	</ul>
 
-	<h3>Visualizations</h3>
+	<h2>Visualizations</h2>
 
 	<form>
     	<label><input type="radio" name="dataset" id="dataset" value="dow" checked>Day of Week</label>

--- a/PlaneType/index.html
+++ b/PlaneType/index.html
@@ -18,7 +18,7 @@
 
   <H1>Which type of planes are most susceptible to delays?</H1>
 
-  <h3>Source of Data</h3>
+  <h2>Source of Data</h2>
   <p>Data was gathered from the Department of Transportation's web site  <A HREF="https://transtats.bts.gov/DL_SelectFields.asp?Table_ID=236&DB_Short_Name=On-Time">On-Time Performances table</A>, for all flights departing from the top 50 busiest US airports in 2017.  We chose to look at trends for the 7 most common types of aircraft. </p>
 
   <p>Two charts are below.
@@ -27,7 +27,7 @@ The first is a stacked bar chart which indicates percent occurrence of delay, ca
 
 
 
-  <h3>Insights for Chart 1 - Flights Departing from Boston</h3>
+  <h2>Insights for Chart 1 - Flights Departing from Boston</h2>
   <ul>
   <li>You have the greatest chance of arriving more than 180 minutes late if you fly on a 717</b>.</li>
   <li>You have the greatest chance of arriving early if you fly on either a 737 or A319 (however, the A319 also has the second highest occurrence of flights delayed more than 180 minutes)</li>
@@ -42,7 +42,7 @@ The first is a stacked bar chart which indicates percent occurrence of delay, ca
 </div>
 
 
-  <h3>Insights for Chart 2 - Flights Departing from Top 50 Busiest Airports in US</h3>
+  <h2>Insights for Chart 2 - Flights Departing from Top 50 Busiest Airports in US</h2>
   <ul>
   <li>You have the greatest chance of arriving on-time if you fly on a 717 (note this trend is different from that of just flights departing from Boston).</li>
   <li>You have the lowest chance of arriving on-time if you fly on a CL-600 (note this trend is different from that of just flights departing from Boston)</li>
@@ -55,7 +55,7 @@ The first is a stacked bar chart which indicates percent occurrence of delay, ca
 <script src="chart.js"></script>
 
 
-<h3>Summary</h3>
+<h2>Summary</h2>
 
 
 <p>The results are drastically different when looking at flights departing just from Boston or departing from the 50 busiest airports in the US.</p>

--- a/index.html
+++ b/index.html
@@ -36,10 +36,10 @@
 <p><h2>Authors</h2></p>
 <p> 
 	<ul>
-		<li> Bobi Marciano Gilburd, MC-MPA 18   </li>
-		<li> Erin St. Peter, MPP 19 </li>
-		<li> Chris Hilger, Data Science MS 18 </li>
-		<li> Zain Ul Abideen Shahid, MPA/ID 18 </li>
+		<li> Bobi Marciano Gilburd, MC/MPA '18   </li>
+		<li> Erin St. Peter, MPP '19 </li>
+		<li> Chris Hilger, Data Science MS '18 </li>
+		<li> Zain Ul Abideen Shahid, MPA/ID '18 </li>
 		
 	</ul
 	


### PR DESCRIPTION
All pages starts with h1. subs are h2.
Also add comments on graduation years.